### PR TITLE
fractional digits

### DIFF
--- a/src/features/accounts/components/accounts-menu/accounts-menu.tsx
+++ b/src/features/accounts/components/accounts-menu/accounts-menu.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { FiChevronDown } from "react-icons/fi"
+import { ANON_IDENTITY } from "many-js"
 import { useAccountsStore } from "features/accounts"
 import {
   Box,
   Button,
   Circle,
+  ChevronDownIcon,
   Code,
   CopyToClipboard,
   EditIcon,
@@ -92,7 +93,7 @@ export function AccountsMenu() {
       <Menu autoSelect={false}>
         <MenuButton
           as={Button}
-          rightIcon={<FiChevronDown />}
+          rightIcon={<ChevronDownIcon />}
           leftIcon={<Icon as={UserIcon} w={5} h={5} />}
           size="md"
           aria-label="active account menu trigger"
@@ -149,7 +150,7 @@ export function AccountsMenu() {
           </MenuItem>
         </MenuList>
       </Menu>
-      {idStrs && idStrs.short !== "oaa" && (
+      {idStrs && idStrs.short !== ANON_IDENTITY && (
         <HStack
           display={{ base: "none", md: "inline-flex" }}
           bgColor="gray.100"

--- a/src/features/accounts/types.ts
+++ b/src/features/accounts/types.ts
@@ -1,4 +1,3 @@
-export const ANON_ID = "<oaa>"
 export type AccountId = number
 export type Identity = { publicKey: Uint8Array; privateKey: Uint8Array } | null
 

--- a/src/features/network/components/network-menu/network-menu.tsx
+++ b/src/features/network/components/network-menu/network-menu.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import { FaRegEdit } from "react-icons/fa"
-import { FiChevronDown } from "react-icons/fi"
 import { useNetworkStore } from "../../store"
 import {
   Box,
   Button,
   Circle,
+  ChevronDownIcon,
   Flex,
   FormControl,
   FormLabel,
@@ -58,7 +58,7 @@ export function NetworkMenu() {
       <Menu autoSelect={false}>
         <MenuButton
           as={Button}
-          rightIcon={<FiChevronDown />}
+          rightIcon={<ChevronDownIcon />}
           lineHeight="normal"
           size="md"
           minWidth="100px"

--- a/src/features/transactions/components/txn-list/txn-list.tsx
+++ b/src/features/transactions/components/txn-list/txn-list.tsx
@@ -20,6 +20,7 @@ import {
 } from "components"
 import { useTransactionsList } from "features/transactions/queries"
 import { IdentityText } from "components/uikit/identity-text"
+import { amountFormatter } from "helper/common"
 
 export function TxnList({
   accountPublicKey,
@@ -139,7 +140,7 @@ function SendTxnListItem({
   const TxnIcon = isSender ? SendOutlineIcon : ReceiveIcon
   const title = isSender ? "send" : "receive"
 
-  const displayAmount = `${isSender ? "-" : "+"}${amount}`
+  const displayAmount = `${isSender ? "-" : "+"}${amountFormatter(amount)}`
   const address = isSender ? to! : from!
 
   return (

--- a/src/helper/__tests__/common.test.ts
+++ b/src/helper/__tests__/common.test.ts
@@ -1,0 +1,37 @@
+import { parseNumberToBigInt, amountFormatter } from "../common"
+
+describe("parseNumberToBigInt", () => {
+  it("should output the correct bigint", () => {
+    const expected1 = BigInt(1000000000)
+    const actual1 = parseNumberToBigInt(parseFloat("1.0"))
+    expect(actual1).toEqual(expected1)
+
+    const expected2 = BigInt(1000005599)
+    const actual2 = parseNumberToBigInt(parseFloat("1.000005599"))
+    expect(actual2).toEqual(expected2)
+
+    const expected3 = BigInt(1000000)
+    const actual3 = parseNumberToBigInt(parseFloat(".001"))
+    expect(actual3).toEqual(expected3)
+
+    const expected4 = BigInt(1)
+    const actual4 = parseNumberToBigInt(parseFloat(".000000001"))
+    expect(actual4).toEqual(expected4)
+  })
+})
+
+describe("amountFormatter", () => {
+  it("should format the amount properly", () => {
+    const expected1 = "0.000000001"
+    const actual1 = amountFormatter(BigInt(1))
+    expect(actual1).toEqual(expected1)
+
+    const expected2 = "1"
+    const actual2 = amountFormatter(BigInt(1000000000))
+    expect(actual2).toEqual(expected2)
+
+    const expected3 = "120.000000005"
+    const actual3 = amountFormatter(BigInt(120000000005))
+    expect(actual3).toEqual(expected3)
+  })
+})

--- a/src/helper/__tests__/common.test.ts
+++ b/src/helper/__tests__/common.test.ts
@@ -1,37 +1,43 @@
 import { parseNumberToBigInt, amountFormatter } from "../common"
 
+function setupParseNumberToBigInt(
+  expectedBigInt: bigint,
+  numStr: string,
+  maxDigits?: number,
+) {
+  const actual7 = parseNumberToBigInt(parseFloat(numStr), maxDigits)
+  expect(actual7).toEqual(expectedBigInt)
+}
+
 describe("parseNumberToBigInt", () => {
   it("should output the correct bigint", () => {
-    const expected1 = BigInt(1000000000)
-    const actual1 = parseNumberToBigInt(parseFloat("1.0"))
-    expect(actual1).toEqual(expected1)
-
-    const expected2 = BigInt(1000005599)
-    const actual2 = parseNumberToBigInt(parseFloat("1.000005599"))
-    expect(actual2).toEqual(expected2)
-
-    const expected3 = BigInt(1000000)
-    const actual3 = parseNumberToBigInt(parseFloat(".001"))
-    expect(actual3).toEqual(expected3)
-
-    const expected4 = BigInt(1)
-    const actual4 = parseNumberToBigInt(parseFloat(".000000001"))
-    expect(actual4).toEqual(expected4)
+    setupParseNumberToBigInt(BigInt(1000000000), "1.0")
+    setupParseNumberToBigInt(BigInt(1000005599), "1.000005599")
+    setupParseNumberToBigInt(BigInt(1000000), ".001")
+    setupParseNumberToBigInt(BigInt(1), ".000000001")
+    setupParseNumberToBigInt(BigInt(1), ".00001", 5)
+    setupParseNumberToBigInt(BigInt(10000), ".1", 5)
+    setupParseNumberToBigInt(BigInt(1005490), "10.0549", 5)
   })
 })
 
+function setupAmountFormatter(
+  expectedStr: string,
+  bigIntToFormat: bigint,
+  minDigits?: number,
+  maxDigits?: number,
+) {
+  expect(amountFormatter(bigIntToFormat, minDigits, maxDigits)).toEqual(
+    expectedStr,
+  )
+}
 describe("amountFormatter", () => {
   it("should format the amount properly", () => {
-    const expected1 = "0.000000001"
-    const actual1 = amountFormatter(BigInt(1))
-    expect(actual1).toEqual(expected1)
-
-    const expected2 = "1"
-    const actual2 = amountFormatter(BigInt(1000000000))
-    expect(actual2).toEqual(expected2)
-
-    const expected3 = "120.000000005"
-    const actual3 = amountFormatter(BigInt(120000000005))
-    expect(actual3).toEqual(expected3)
+    setupAmountFormatter("0.000000001", BigInt(1))
+    setupAmountFormatter("1", BigInt(1000000000))
+    setupAmountFormatter("120.000000005", BigInt(120000000005))
+    setupAmountFormatter("1.5", BigInt(150000), undefined, 5)
+    setupAmountFormatter("155.55559", BigInt(15555559), undefined, 5)
+    setupAmountFormatter("9,155.55559", BigInt(915555559), undefined, 5)
   })
 })

--- a/src/helper/__tests__/common.test.ts
+++ b/src/helper/__tests__/common.test.ts
@@ -5,8 +5,9 @@ function setupParseNumberToBigInt(
   numStr: string,
   maxDigits?: number,
 ) {
-  const actual7 = parseNumberToBigInt(parseFloat(numStr), maxDigits)
-  expect(actual7).toEqual(expectedBigInt)
+  expect(parseNumberToBigInt(parseFloat(numStr), maxDigits)).toEqual(
+    expectedBigInt,
+  )
 }
 
 describe("parseNumberToBigInt", () => {

--- a/src/helper/common.ts
+++ b/src/helper/common.ts
@@ -1,6 +1,8 @@
 import { Identity, ANON_IDENTITY } from "many-js"
 import { Account } from "../store/accounts"
 
+const DEFAULT_MAX_DIGITS = 9
+
 export const parseIdentity = (key: any): string => {
   if (key === undefined) {
     return ANON_IDENTITY
@@ -27,14 +29,20 @@ export function displayId(account: Account): { full: string; short: string } {
   return { full: idString, short: makeShortId(idString) }
 }
 
-export const parseNumberToBigInt = (v: number) =>
-  BigInt(Math.round(v * 10 ** 9))
+export const parseNumberToBigInt = (
+  v: number,
+  maxDigits: number = DEFAULT_MAX_DIGITS,
+) => BigInt(Math.round(v * 10 ** maxDigits))
 
-export const amountFormatter = (amt: bigint, min?: number, max?: number) => {
-  const amount = parseFloat(amt.toString()) / 10 ** 9
+export const amountFormatter = (
+  amt: bigint,
+  minDigits: number = 0,
+  maxDigits: number = DEFAULT_MAX_DIGITS,
+) => {
+  const amount = parseFloat(amt.toString()) / 10 ** maxDigits
   const amountString = new Intl.NumberFormat("en-US", {
-    minimumFractionDigits: min ?? 0,
-    maximumFractionDigits: max ?? 9,
+    minimumFractionDigits: minDigits,
+    maximumFractionDigits: maxDigits,
   }).format(amount)
 
   return amountString

--- a/src/helper/common.ts
+++ b/src/helper/common.ts
@@ -1,28 +1,41 @@
-import { Identity } from "many-js";
-import { Account } from "../store/accounts";
+import { Identity, ANON_IDENTITY } from "many-js"
+import { Account } from "../store/accounts"
 
 export const parseIdentity = (key: any): string => {
   if (key === undefined) {
-    return "<oaa>";
+    return ANON_IDENTITY
   }
-  const identity = Identity.fromPublicKey(key);
+  const identity = Identity.fromPublicKey(key)
 
-  return `<${identity.toString()}>`;
-};
+  return `${identity.toString()}`
+}
 
 export const getAddressFromHex = (hex: any): string => {
-  const identity = Identity.fromHex(hex);
-  return identity.toString();
-};
+  const identity = Identity.fromHex(hex)
+  return identity.toString()
+}
 
 export const makeShortId = (idString: string): string =>
-  `<${idString.slice(0, 4)}...${idString.slice(-4)}>`
+  `${idString.slice(0, 4)}...${idString.slice(-4)}`
 
 export function displayId(account: Account): { full: string; short: string } {
   if (!account?.keys) {
-    return { full: "", short: `<oaa>` }
+    return { full: "", short: ANON_IDENTITY }
   }
   const identity = Identity.fromPublicKey(account.keys.publicKey)
   const idString = identity.toString()
   return { full: idString, short: makeShortId(idString) }
+}
+
+export const parseNumberToBigInt = (v: number) =>
+  BigInt(Math.round(v * 10 ** 9))
+
+export const amountFormatter = (amt: bigint, min?: number, max?: number) => {
+  const amount = parseFloat(amt.toString()) / 10 ** 9
+  const amountString = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: min ?? 0,
+    maximumFractionDigits: max ?? 9,
+  }).format(amount)
+
+  return amountString
 }

--- a/src/views/_home/__tests__/home.test.tsx
+++ b/src/views/_home/__tests__/home.test.tsx
@@ -115,14 +115,10 @@ describe("home page", () => {
     setupHome()
 
     expect(screen.getByText(/abc/i)).toBeInTheDocument()
-    expect(
-      screen.getByText(BigInt(1000000).toLocaleString()),
-    ).toBeInTheDocument()
+    expect(screen.getByText("0.001")).toBeInTheDocument()
 
     expect(screen.getByText(/ghi/i)).toBeInTheDocument()
-    expect(
-      screen.getByText(BigInt(5000000).toLocaleString()),
-    ).toBeInTheDocument()
+    expect(screen.getByText("0.005")).toBeInTheDocument()
   })
   it("should display an error message", async () => {
     useNetworkContext.mockImplementationOnce(() => {
@@ -173,7 +169,7 @@ describe("home page", () => {
     await waitFor(() => screen.findByText(/abc/i))
     const assets = await screen.findAllByLabelText(/asset list item/i)
     userEvent.click(assets[0])
-    expect(screen.getByText(/1,000,000 abc/i)).toBeInTheDocument()
+    expect(screen.getByText(/0.001 abc/i)).toBeInTheDocument()
     await waitFor(() =>
       expect(mockNetwork.ledger.list).toHaveBeenCalledTimes(1),
     )
@@ -183,16 +179,14 @@ describe("home page", () => {
     const firstTxn = within(rows[0])
     expect(firstTxn.getByText(/abc/i)).toBeInTheDocument()
     expect(firstTxn.getByText(/send/i)).toBeInTheDocument()
-    expect(firstTxn.getByText(/-1/i)).toBeInTheDocument()
+    expect(firstTxn.getByText(/-0.000000001/i)).toBeInTheDocument()
     expect(firstTxn.getByText(/4\/8\/2022, 8:03:00 AM/i)).toBeInTheDocument()
 
     const secondTxn = within(rows[1])
     expect(secondTxn.getByText(/abc/i)).toBeInTheDocument()
     expect(secondTxn.getByText(/receive/i)).toBeInTheDocument()
-    expect(secondTxn.getByText(/\+3/i)).toBeInTheDocument()
+    expect(secondTxn.getByText(/\+0.000000003/i)).toBeInTheDocument()
     expect(secondTxn.getByText(/4\/8\/2022, 8:01:00 AM/i)).toBeInTheDocument()
-
-    screen.debug(rows)
   })
   it("should show list of account transaction history", async () => {
     const { activityTab } = setupHome()
@@ -207,12 +201,12 @@ describe("home page", () => {
     expect(rows.length).toEqual(2)
     expect(screen.getByText(/send/i)).toBeInTheDocument()
     expect(screen.getByText(/4\/8\/2022, 8:03:00 AM/i)).toBeInTheDocument()
-    expect(screen.getByText(/-1/i)).toBeInTheDocument()
+    expect(screen.getByText(/-0.000000001/i)).toBeInTheDocument()
     expect(screen.getByText(/abc/i)).toBeInTheDocument()
 
     expect(screen.getByText(/receive/i)).toBeInTheDocument()
     expect(screen.getByText(/4\/8\/2022, 8:01:00 AM/i)).toBeInTheDocument()
-    expect(screen.getByText(/\+3/i)).toBeInTheDocument()
+    expect(screen.getByText(/\+0.000000003/i)).toBeInTheDocument()
     expect(screen.getByText(/ghi/i)).toBeInTheDocument()
   })
 })

--- a/src/views/_home/asset-details/asset-details.tsx
+++ b/src/views/_home/asset-details/asset-details.tsx
@@ -12,7 +12,7 @@ import { TxnList } from "features/transactions"
 import cubeImg from "assets/cube.png"
 import { Asset } from "features/balances"
 import { Network } from "many-js"
-import { makeShortId } from "helper/common"
+import { amountFormatter, makeShortId } from "helper/common"
 
 type Props = {
   asset: Asset
@@ -39,7 +39,7 @@ export function AssetDetails({
       <VStack>
         <Image src={cubeImg} boxSize="14" />
         <Heading size="lg" fontWeight="normal">
-          {asset.balance.toLocaleString() || "0"} {asset.symbol}
+          {amountFormatter(asset.balance)} {asset.symbol}
         </Heading>
         <Flex alignItems="center" gap={1}>
           <Text>{makeShortId(asset.identity)}</Text>

--- a/src/views/_home/symbols/symbols.tsx
+++ b/src/views/_home/symbols/symbols.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link as RouterLink } from "react-router-dom"
-import { GrSend } from "react-icons/gr"
 import { Network } from "many-js"
 import {
   Button,
@@ -8,6 +7,7 @@ import {
   HStack,
   Icon,
   Image,
+  SendOutlineIcon,
   Spinner,
   Stack,
   StackDivider,
@@ -16,6 +16,7 @@ import {
 } from "components"
 import { Asset, useBalances } from "features/balances"
 import cubeImg from "assets/cube.png"
+import { amountFormatter } from "helper/common"
 
 export function Symbols({
   network,
@@ -118,17 +119,17 @@ function AssetLlistItem({
           fontSize="xl"
           fontWeight="medium"
         >
-          {asset.balance.toLocaleString()}
+          {amountFormatter(asset.balance)}
         </Text>
         <Text fontSize="lg" casing="uppercase" lineHeight="normal">
           {asset.symbol}
         </Text>
       </HStack>
       <Button
-        leftIcon={<Icon as={GrSend} />}
+        leftIcon={<Icon as={SendOutlineIcon} />}
         display={{
-          base: "inline-flex",
-          md: showActions ? "inline-block" : "none",
+          base: "flex",
+          md: showActions ? "flex" : "none",
         }}
         variant="link"
         as={RouterLink}

--- a/src/views/send-asset/__tests__/send-asset.test.tsx
+++ b/src/views/send-asset/__tests__/send-asset.test.tsx
@@ -54,17 +54,14 @@ describe("<SendAsset />", () => {
     userEvent.click(selectTokenBtn)
     const assets = screen.getAllByLabelText(/select asset/i)
     const firstAsset = assets[0]
-    const { symbol: selectedAssetSymbol, balance: selectedAssetBalance } =
-      ownedAssetsWithBalance[0]
+    const { symbol: selectedAssetSymbol } = ownedAssetsWithBalance[0]
     const form = screen.getByRole("form")
     userEvent.click(firstAsset)
     expect(
       within(form).getByText(new RegExp(selectedAssetSymbol, "i")),
     ).toBeInTheDocument()
     expect(
-      within(form).getByText(
-        new RegExp("balance: " + selectedAssetBalance.toLocaleString(), "i"),
-      ),
+      within(form).getByText(new RegExp("balance: 0.001", "i")),
     ).toBeInTheDocument()
 
     fireEvent.change(toInput, {

--- a/src/views/send-asset/send-asset.tsx
+++ b/src/views/send-asset/send-asset.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { useLocation } from "react-router-dom"
-import { FiChevronDown } from "react-icons/fi"
 import {
   AlertDialog,
   AlertDialogProps,
@@ -8,6 +7,7 @@ import {
   ButtonGroup,
   Box,
   Checkbox,
+  ChevronDownIcon,
   Container,
   Grid,
   GridItem,
@@ -24,7 +24,6 @@ import {
   useToast,
   useDisclosure,
   VStack,
-  CopyToClipboard,
 } from "components"
 import { AssetSelector } from "./asset-selector"
 import cubeImg from "assets/cube.png"
@@ -33,9 +32,8 @@ import { useAccountsStore } from "features/accounts"
 import { useBalances } from "features/balances"
 import { useSendToken } from "features/transactions"
 import { Contact, ContactSelector } from "features/contacts"
-
 import { Asset } from "features/balances"
-import { displayId } from "helper/common"
+import { amountFormatter, displayId, parseNumberToBigInt } from "helper/common"
 import { IdentityText } from "components/uikit/identity-text"
 
 const defaultFormState: {
@@ -80,10 +78,11 @@ export function SendAsset() {
 
   async function onSendTxn(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
+    const bigIntAmount = parseNumberToBigInt(parseFloat(formValues.amount!))
     sendToken(
       {
         to: formValues.to,
-        amount: BigInt(formValues.amount!),
+        amount: bigIntAmount,
         symbol: formValues.asset!.identity,
       },
       {
@@ -154,7 +153,7 @@ export function SendAsset() {
                           <Button
                             size="sm"
                             variant="link"
-                            rightIcon={<FiChevronDown />}
+                            rightIcon={<ChevronDownIcon boxSize={4} />}
                             onClick={onOpen}
                           >
                             Select a contact
@@ -180,7 +179,7 @@ export function SendAsset() {
                     variant="unstyled"
                     onChange={onChange}
                     value={formValues.to}
-                    placeholder="oaffbahksdwaqeenayy..."
+                    placeholder="maffbahksdwaqeenayy..."
                     pattern="^[a-z0-9]*$"
                     minLength={50}
                     maxLength={50}
@@ -207,7 +206,7 @@ export function SendAsset() {
                       {onOpen => (
                         <Button
                           size="sm"
-                          rightIcon={<FiChevronDown />}
+                          rightIcon={<ChevronDownIcon boxSize={4} />}
                           aria-label="select token"
                           onClick={onOpen}
                           variant="link"
@@ -228,7 +227,8 @@ export function SendAsset() {
                     value={formValues.amount ?? ""}
                     placeholder="0.0"
                     required
-                    pattern="^[0-9]*[.,]?[0-9]*$"
+                    pattern="^(\d?)+(?:\.\d{1,9})?$"
+                    title="Number with up to 9 decimal places"
                     fontFamily="monospace"
                     size="lg"
                   />
@@ -245,7 +245,7 @@ export function SendAsset() {
                         </HStack>
                         <HStack>
                           <Text whiteSpace="nowrap" fontSize="xs">
-                            Balance: {asset.balance.toLocaleString()}
+                            Balance: {amountFormatter(asset.balance)}
                           </Text>
                           <Button
                             variant="link"
@@ -254,7 +254,7 @@ export function SendAsset() {
                             onClick={() => {
                               setFormValues(s => ({
                                 ...s,
-                                amount: asset.balance.toString(),
+                                amount: amountFormatter(asset.balance),
                               }))
                             }}
                           >
@@ -364,13 +364,13 @@ function ConfirmTxnDialog({
             <GridItem mt={{ base: 6, md: 0 }}>
               <FormLabel m={0}>Amount</FormLabel>
             </GridItem>
-            <GridItem paddingInlineStart={{ base: 4, md: 0 }}>
+            <GridItem overflow="hidden" paddingInlineStart={{ base: 4, md: 0 }}>
               <HStack spacing={1}>
                 <Image src={cubeImg} borderRadius="full" boxSize={9} />
-                <Text fontSize="2xl" isTruncated>
+                <Text fontSize="lg" isTruncated>
                   {txnDetails.amount}
                 </Text>
-                <Text fontSize="2xl">{txnDetails.asset?.symbol}</Text>
+                <Text fontSize="lg">{txnDetails.asset?.symbol}</Text>
               </HStack>
             </GridItem>
           </Grid>


### PR DESCRIPTION
- adds 9 fractional digits to amount

ex when displaying amount:
900000 FBT would be displayed as `.0009 FBT`
1 FBT would be displayed as `.000000001 FBT`

ex when sending amount:
user enters `1 FBT`, actual value sent is `1000000000n FBT` (big int)
user enters `.001 FBT`, actual value sent is `1000000n FBT` (big int)